### PR TITLE
Use ENV['SECRET_KEY_BASE'] for production

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -5,4 +5,5 @@ test:
   secret_key_base: 'testtesttesttesttesttesttesttest'
  
 production:
-  secret_key_base: ENV['RAILS_SECRET_TOKEN']
+  secret_key_base: ENV['SECRET_KEY_BASE']
+  


### PR DESCRIPTION
ENV['SECRET_KEY_BASE'] is the default used by 'rails new' (at least v4.1.6) and might make a better example.